### PR TITLE
Fix Renovate preset configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "group:monorepos",
-    "group:typos"
+    "group:monorepos"
   ],
   "major": {
     "enabled": false


### PR DESCRIPTION
## Summary

Removes the invalid `group:typos` Renovate preset from `renovate.json`.

## Root cause

Renovate opened issue #114 because the config extends `group:typos`, which Renovate cannot resolve. When Renovate cannot resolve a preset, it stops creating PRs as a precaution.

## Validation

- Confirmed `renovate.json` now parses as JSON.
- Confirmed the only config change is removing `group:typos` from `extends`.
- Left `config:recommended`, `group:monorepos`, PR limits, labels, and package rules unchanged.

## PR automation notes

This should unblock Renovate config loading. Existing automation behavior is intentionally unchanged:

- Major updates remain disabled via `major.enabled: false`.
- Patch and minor updates still request automerge.
- PR throttling remains `prHourlyLimit: 2` and `prConcurrentLimit: 10`.

After merge, verify Renovate reprocesses the repo and issue #114 stops recurring or gets closed.